### PR TITLE
Add unit tests and apply clippy recommendations

### DIFF
--- a/src/app/change.rs
+++ b/src/app/change.rs
@@ -38,3 +38,90 @@ impl App {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::state::AppState;
+    use crate::config::Config;
+
+    fn make_app(data: Vec<u8>) -> App {
+        App {
+            config: Config::default(),
+            file_name: String::new(),
+            data,
+            starting_line: 0,
+            cursor_x: 0,
+            cursor_y: 0,
+            frame_height: 20,
+            running: true,
+            state: AppState::Move,
+            buffer: [' ', ' '],
+            changes: Vec::new(),
+            made_changes: Vec::new(),
+            is_inserting: false,
+            is_selecting: false,
+            selection_start: 0,
+            clipboard: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn do_change_edit_modifies_data() {
+        let mut app = make_app(vec![0x00, 0x01, 0x02]);
+        app.do_change(Change::Edit(1, vec![0x01], vec![0xFF]));
+        assert_eq!(app.data[1], 0xFF);
+        assert_eq!(app.changes.len(), 1);
+    }
+
+    #[test]
+    fn undo_edit_reverts_data() {
+        let mut app = make_app(vec![0x00, 0x01, 0x02]);
+        app.do_change(Change::Edit(1, vec![0x01], vec![0xFF]));
+        app.undo();
+        assert_eq!(app.data[1], 0x01);
+        assert_eq!(app.changes.len(), 0);
+        assert_eq!(app.made_changes.len(), 1);
+    }
+
+    #[test]
+    fn redo_reapplies_edit() {
+        let mut app = make_app(vec![0x00, 0x01, 0x02]);
+        app.do_change(Change::Edit(1, vec![0x01], vec![0xFF]));
+        app.undo();
+        app.redo();
+        assert_eq!(app.data[1], 0xFF);
+    }
+
+    #[test]
+    fn do_change_insert_increases_len() {
+        let mut app = make_app(vec![0x00, 0x02]);
+        app.do_change(Change::Insert(1, vec![0xAB]));
+        assert_eq!(app.data.len(), 3);
+        assert_eq!(app.data[1], 0xAB);
+    }
+
+    #[test]
+    fn undo_insert_removes_bytes() {
+        let mut app = make_app(vec![0x00, 0x02]);
+        app.do_change(Change::Insert(1, vec![0xAB]));
+        app.undo();
+        assert_eq!(app.data, vec![0x00, 0x02]);
+    }
+
+    #[test]
+    fn do_change_delete_decreases_len() {
+        let mut app = make_app(vec![0x00, 0x01, 0x02]);
+        app.do_change(Change::Delete(1, vec![0x01]));
+        assert_eq!(app.data.len(), 2);
+        assert_eq!(app.data[1], 0x02);
+    }
+
+    #[test]
+    fn undo_delete_restores_bytes() {
+        let mut app = make_app(vec![0x00, 0x01, 0x02]);
+        app.do_change(Change::Delete(1, vec![0x01]));
+        app.undo();
+        assert_eq!(app.data, vec![0x00, 0x01, 0x02]);
+    }
+}

--- a/src/app/events.rs
+++ b/src/app/events.rs
@@ -52,7 +52,7 @@ impl App {
                     //since cursor can also be outside data check this lol;
                     if x == y && y == self.data.len() {
                         self.move_left();
-                        return ();
+                        return;
                     }
 
                     let old = self.data[x..(y + 1)].to_vec();

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -125,7 +125,7 @@ impl App {
                         .fg(self.config.colorscheme.primary)
                         .reversed()
                 } else if pos < self.data.len() {
-                    let byte = Byte::new(self.data[pos as usize]);
+                    let byte = Byte::new(self.data[pos]);
                     let mut style = byte.get_style(&self.config);
                     style = if cursor_here {
                         match self.is_selecting {
@@ -174,7 +174,7 @@ impl App {
                     true => {
                         let (x, y) = self.selection_range();
                         if x <= pos && pos < y {
-                            spacing.bg(self.config.colorscheme.select).into()
+                            spacing.bg(self.config.colorscheme.select)
                         } else {
                             spacing.into()
                         }

--- a/src/app/utils.rs
+++ b/src/app/utils.rs
@@ -48,7 +48,7 @@ impl App {
     }
     pub fn move_right(&mut self) {
         self.cursor_x += 1;
-        if self.get_idx() >= self.data.len() + 1 {
+        if self.get_idx() > self.data.len() {
             self.cursor_x -= 1;
         }
         if self.cursor_x >= 16 {

--- a/src/app/utils.rs
+++ b/src/app/utils.rs
@@ -138,3 +138,208 @@ impl App {
             .unwrap();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::state::AppState;
+    use crate::config::Config;
+
+    fn make_app(data: Vec<u8>) -> App {
+        App {
+            config: Config::default(),
+            file_name: String::new(),
+            data,
+            starting_line: 0,
+            cursor_x: 0,
+            cursor_y: 0,
+            frame_height: 20,
+            running: true,
+            state: AppState::Move,
+            buffer: [' ', ' '],
+            changes: Vec::new(),
+            made_changes: Vec::new(),
+            is_inserting: false,
+            is_selecting: false,
+            selection_start: 0,
+            clipboard: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn get_idx_origin() {
+        let app = make_app(vec![0u8; 32]);
+        assert_eq!(app.get_idx(), 0);
+    }
+
+    #[test]
+    fn get_idx_x_offset() {
+        let mut app = make_app(vec![0u8; 32]);
+        app.cursor_x = 5;
+        assert_eq!(app.get_idx(), 5);
+    }
+
+    #[test]
+    fn get_idx_y_offset() {
+        let mut app = make_app(vec![0u8; 32]);
+        app.cursor_y = 1;
+        assert_eq!(app.get_idx(), 16);
+    }
+
+    #[test]
+    fn set_idx_row_col() {
+        let mut app = make_app(vec![0u8; 64]);
+        app.set_idx(35);
+        assert_eq!(app.cursor_y, 2);
+        assert_eq!(app.cursor_x, 3);
+    }
+
+    #[test]
+    fn move_right_increments_x() {
+        let mut app = make_app(vec![0u8; 32]);
+        app.move_right();
+        assert_eq!(app.cursor_x, 1);
+    }
+
+    #[test]
+    fn move_right_wraps_to_next_row() {
+        let mut app = make_app(vec![0u8; 32]);
+        app.cursor_x = 15;
+        app.move_right();
+        assert_eq!(app.cursor_x, 0);
+        assert_eq!(app.cursor_y, 1);
+    }
+
+    #[test]
+    fn move_left_decrements_x() {
+        let mut app = make_app(vec![0u8; 32]);
+        app.cursor_x = 5;
+        app.move_left();
+        assert_eq!(app.cursor_x, 4);
+    }
+
+    #[test]
+    fn move_left_wraps_to_prev_row() {
+        let mut app = make_app(vec![0u8; 32]);
+        app.cursor_y = 1;
+        app.move_left();
+        assert_eq!(app.cursor_x, 15);
+        assert_eq!(app.cursor_y, 0);
+    }
+
+    #[test]
+    fn move_left_at_origin_does_nothing() {
+        let mut app = make_app(vec![0u8; 32]);
+        app.move_left();
+        assert_eq!(app.cursor_x, 0);
+        assert_eq!(app.cursor_y, 0);
+    }
+
+    #[test]
+    fn move_down_increments_y() {
+        let mut app = make_app(vec![0u8; 32]);
+        app.move_down();
+        assert_eq!(app.cursor_y, 1);
+    }
+
+    #[test]
+    fn move_up_decrements_y() {
+        let mut app = make_app(vec![0u8; 32]);
+        app.cursor_y = 2;
+        app.move_up();
+        assert_eq!(app.cursor_y, 1);
+    }
+
+    #[test]
+    fn move_up_at_zero_does_nothing() {
+        let mut app = make_app(vec![0u8; 32]);
+        app.move_up();
+        assert_eq!(app.cursor_y, 0);
+    }
+
+    #[test]
+    fn insert_to_buffer_first_char() {
+        let mut app = make_app(vec![]);
+        app.insert_to_buffer('a');
+        assert_eq!(app.buffer[0], 'A');
+        assert_eq!(app.buffer[1], ' ');
+    }
+
+    #[test]
+    fn insert_to_buffer_second_char() {
+        let mut app = make_app(vec![]);
+        app.insert_to_buffer('f');
+        app.insert_to_buffer('3');
+        assert_eq!(app.buffer[0], 'F');
+        assert_eq!(app.buffer[1], '3');
+    }
+
+    #[test]
+    fn buffer_to_u8_max() {
+        let mut app = make_app(vec![]);
+        app.buffer = ['F', 'F'];
+        assert_eq!(app.buffer_to_u8(), 255);
+    }
+
+    #[test]
+    fn buffer_to_u8_zero() {
+        let mut app = make_app(vec![]);
+        app.buffer = ['0', '0'];
+        assert_eq!(app.buffer_to_u8(), 0);
+    }
+
+    #[test]
+    fn replace_data_modifies_byte() {
+        let mut app = make_app(vec![0x00, 0x01, 0x02]);
+        app.replace_data(1, vec![0xAB]);
+        assert_eq!(app.data[1], 0xAB);
+    }
+
+    #[test]
+    fn insert_data_inserts_byte() {
+        let mut app = make_app(vec![0x00, 0x02]);
+        app.insert_data(1, vec![0x01]);
+        assert_eq!(app.data, vec![0x00, 0x01, 0x02]);
+    }
+
+    #[test]
+    fn delete_data_removes_byte() {
+        let mut app = make_app(vec![0x00, 0x01, 0x02]);
+        app.delete_data(1, 1);
+        assert_eq!(app.data, vec![0x00, 0x02]);
+    }
+
+    #[test]
+    fn selection_range_when_not_selecting() {
+        let mut app = make_app(vec![0u8; 32]);
+        app.cursor_x = 3;
+        app.cursor_y = 1;
+        let (min, max) = app.selection_range();
+        assert_eq!(min, 19);
+        assert_eq!(max, 19);
+    }
+
+    #[test]
+    fn selection_range_forward() {
+        let mut app = make_app(vec![0u8; 32]);
+        app.is_selecting = true;
+        app.selection_start = 5;
+        app.cursor_x = 10;
+        app.cursor_y = 0;
+        let (min, max) = app.selection_range();
+        assert_eq!(min, 5);
+        assert_eq!(max, 10);
+    }
+
+    #[test]
+    fn selection_range_reverse() {
+        let mut app = make_app(vec![0u8; 32]);
+        app.is_selecting = true;
+        app.selection_start = 10;
+        app.cursor_x = 5;
+        app.cursor_y = 0;
+        let (min, max) = app.selection_range();
+        assert_eq!(min, 5);
+        assert_eq!(max, 10);
+    }
+}

--- a/src/byte.rs
+++ b/src/byte.rs
@@ -44,3 +44,76 @@ impl Byte {
         config.colorscheme.get_style(self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bytetype_null() {
+        assert!(matches!(Byte::new(0).get_bytetype(), ByteType::Null));
+    }
+
+    #[test]
+    fn bytetype_ascii_printable() {
+        assert!(matches!(
+            Byte::new(b'A').get_bytetype(),
+            ByteType::AsciiPrintable
+        ));
+    }
+
+    #[test]
+    fn bytetype_ascii_whitespace() {
+        assert!(matches!(
+            Byte::new(b'\t').get_bytetype(),
+            ByteType::AsciiWhitespace
+        ));
+        assert!(matches!(
+            Byte::new(b' ').get_bytetype(),
+            ByteType::AsciiWhitespace
+        ));
+    }
+
+    #[test]
+    fn bytetype_ascii_other() {
+        // SOH (0x01) is ASCII control but not graphic, not whitespace, not null
+        assert!(matches!(
+            Byte::new(1).get_bytetype(),
+            ByteType::AsciiOther
+        ));
+    }
+
+    #[test]
+    fn bytetype_non_ascii() {
+        assert!(matches!(
+            Byte::new(128).get_bytetype(),
+            ByteType::NonAscii
+        ));
+        assert!(matches!(
+            Byte::new(255).get_bytetype(),
+            ByteType::NonAscii
+        ));
+    }
+
+    #[test]
+    fn get_hex_zero() {
+        assert_eq!(Byte::new(0).get_hex(), "00");
+    }
+
+    #[test]
+    fn get_hex_single_digit() {
+        assert_eq!(Byte::new(10).get_hex(), "0A");
+    }
+
+    #[test]
+    fn get_hex_max() {
+        assert_eq!(Byte::new(255).get_hex(), "FF");
+    }
+
+    #[test]
+    fn value_roundtrip() {
+        assert_eq!(Byte::new(42).value(), 42);
+        assert_eq!(Byte::new(0).value(), 0);
+        assert_eq!(Byte::new(255).value(), 255);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,14 +112,14 @@ impl Config {
     fn set_color_field(table: &Table, field: &str, current: &mut Color) -> Result<(), String> {
         if let Some(value) = table.get(field) {
             let color = Config::toml_value_to_color(value);
-            if color.is_err() {
-                return Err(format!(
-                    "Invalid color for field '{}' - {}",
-                    field,
-                    color.err().unwrap()
-                ));
-            } else {
-                *current = color.unwrap()
+            match color {
+                Ok(color) => *current = color,
+                Err(color_error) => {
+                    return Err(format!(
+                        "Invalid color for field '{}' - {}",
+                        field, color_error
+                    ));
+                }
             }
         }
         Ok(())
@@ -156,41 +156,41 @@ impl Config {
 
         let values = config_file.unwrap().parse::<Table>().unwrap();
 
-        if let Some(colors) = values.get("theme") {
-            if let Some(table) = colors.as_table() {
-                Config::set_color_field(table, "null", &mut config.colorscheme.null)?;
-                Config::set_color_field(
-                    table,
-                    "ascii_printable",
-                    &mut config.colorscheme.ascii_printable,
-                )?;
-                Config::set_color_field(
-                    table,
-                    "ascii_whitespace",
-                    &mut config.colorscheme.ascii_whitespace,
-                )?;
-                Config::set_color_field(table, "ascii_other", &mut config.colorscheme.ascii_other)?;
-                Config::set_color_field(table, "non_ascii", &mut config.colorscheme.non_ascii)?;
-                Config::set_color_field(table, "accent", &mut config.colorscheme.accent)?;
-                Config::set_color_field(table, "select", &mut config.colorscheme.select)?;
-                Config::set_color_field(table, "primary", &mut config.colorscheme.primary)?;
-                Config::set_color_field(table, "border", &mut config.colorscheme.border)?;
-                Config::set_color_field(table, "background", &mut config.colorscheme.background)?;
-            }
+        if let Some(colors) = values.get("theme")
+            && let Some(table) = colors.as_table()
+        {
+            Config::set_color_field(table, "null", &mut config.colorscheme.null)?;
+            Config::set_color_field(
+                table,
+                "ascii_printable",
+                &mut config.colorscheme.ascii_printable,
+            )?;
+            Config::set_color_field(
+                table,
+                "ascii_whitespace",
+                &mut config.colorscheme.ascii_whitespace,
+            )?;
+            Config::set_color_field(table, "ascii_other", &mut config.colorscheme.ascii_other)?;
+            Config::set_color_field(table, "non_ascii", &mut config.colorscheme.non_ascii)?;
+            Config::set_color_field(table, "accent", &mut config.colorscheme.accent)?;
+            Config::set_color_field(table, "select", &mut config.colorscheme.select)?;
+            Config::set_color_field(table, "primary", &mut config.colorscheme.primary)?;
+            Config::set_color_field(table, "border", &mut config.colorscheme.border)?;
+            Config::set_color_field(table, "background", &mut config.colorscheme.background)?;
         }
 
-        if let Some(charset) = values.get("charset") {
-            if let Some(table) = charset.as_table() {
-                Config::set_charset_field(table, "null", &mut config.charset.null)?;
-                Config::set_charset_field(
-                    table,
-                    "ascii_whitespace",
-                    &mut config.charset.ascii_whitespace,
-                )?;
-                Config::set_charset_field(table, "ascii_other", &mut config.charset.ascii_other)?;
-                Config::set_charset_field(table, "non_ascii", &mut config.charset.non_ascii)?;
-                Config::set_charset_field(table, "non_ascii", &mut config.charset.non_ascii)?;
-            }
+        if let Some(charset) = values.get("charset")
+            && let Some(table) = charset.as_table()
+        {
+            Config::set_charset_field(table, "null", &mut config.charset.null)?;
+            Config::set_charset_field(
+                table,
+                "ascii_whitespace",
+                &mut config.charset.ascii_whitespace,
+            )?;
+            Config::set_charset_field(table, "ascii_other", &mut config.charset.ascii_other)?;
+            Config::set_charset_field(table, "non_ascii", &mut config.charset.non_ascii)?;
+            Config::set_charset_field(table, "non_ascii", &mut config.charset.non_ascii)?;
         }
 
         Ok(config)

--- a/src/config.rs
+++ b/src/config.rs
@@ -196,3 +196,59 @@ impl Config {
         Ok(config)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::style::Color;
+
+    #[test]
+    fn default_does_not_panic() {
+        let config = Config::default();
+        assert_eq!(config.colorscheme.ascii_printable, Color::Blue);
+        assert_eq!(config.charset.null, '.');
+    }
+
+    #[test]
+    fn toml_value_to_color_named() {
+        let val = toml::Value::String("white".to_string());
+        assert_eq!(Config::toml_value_to_color(&val), Ok(Color::White));
+    }
+
+    #[test]
+    fn toml_value_to_color_index() {
+        let val = toml::Value::Integer(196);
+        assert_eq!(Config::toml_value_to_color(&val), Ok(Color::Indexed(196)));
+    }
+
+    #[test]
+    fn toml_value_to_color_rgb() {
+        let val = toml::Value::Array(vec![
+            toml::Value::Integer(255),
+            toml::Value::Integer(0),
+            toml::Value::Integer(128),
+        ]);
+        assert_eq!(
+            Config::toml_value_to_color(&val),
+            Ok(Color::Rgb(255, 0, 128))
+        );
+    }
+
+    #[test]
+    fn toml_value_to_color_invalid_name() {
+        let val = toml::Value::String("not_a_real_color_xyz".to_string());
+        assert!(Config::toml_value_to_color(&val).is_err());
+    }
+
+    #[test]
+    fn toml_value_to_color_index_out_of_range() {
+        let val = toml::Value::Integer(256);
+        assert!(Config::toml_value_to_color(&val).is_err());
+    }
+
+    #[test]
+    fn read_config_missing_file_returns_default() {
+        let result = Config::read_config("/nonexistent/path/hexhog_test_config.toml");
+        assert!(result.is_ok());
+    }
+}


### PR DESCRIPTION
### Clippy fixes

  Minor code quality improvements flagged by `cargo clippy`:

  - `events.rs`: `return ();` → `return`
  - `render.rs`: removed redundant `usize` cast and trailing `.into()` on an already-compatible type
  - `utils.rs`: `>= self.data.len() + 1` → `> self.data.len()` (equivalent, idiomatic)
  - `config.rs`: `if/else` on `Result` → `match`; nested `if let` blocks → let-chains (`if let A && let B`)

  ### Unit tests (45 tests, 0 new dependencies)

  Tests are added inline (`#[cfg(test)]`) to the four pure-logic modules. TUI-dependent modules
  (`render.rs`, `events.rs`, `state.rs`) are excluded as they require a live terminal.

  | File | Tests |
  |---|---|
  | `src/byte.rs` | `ByteType` classification for all 5 variants, `get_hex()`, `value()` |
  | `src/config.rs` | `toml_value_to_color()` for named/index/RGB + error cases, `read_config()` with missing file, `Config::default()` |
  | `src/app/change.rs` | `do_change`/`undo`/`redo` for Edit, Insert, and Delete variants |
  | `src/app/utils.rs` | `get_idx`/`set_idx`, all cursor movement, buffer ops, af`replace/insert/delete_data`, `selection_range` |

  `cargo test` passes locally with all 45 tests green.